### PR TITLE
fix non-breaking urls in sidenote

### DIFF
--- a/static/css/tufte.css
+++ b/static/css/tufte.css
@@ -62,6 +62,19 @@ body {
   /* add space between thead row and tbody */ }
   .wrap .mathblock {
     font-size: 1rem; }
+  .wrap a {
+	  overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    /* This is the dangerous one in WebKit, as it breaks things wherever */
+    word-break: break-all;
+    /* Instead use this non-standard one: */
+    word-break: break-word;
+    /* Adds a hyphen where the word breaks, if supported (No Blink) */
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto; }
   .wrap a, .wrap a:visited {
     color: #A5452B;
     text-decoration: none; }


### PR DESCRIPTION
I noticed on my own site that sidenotes and marginnotes with links were a mess. the links didn't break into the container they were supposed to stay in unless there was a hyphen present. This cleans that up. 

I thought that you might be able to use it as well. I put it where I thought it made the most sense. 

Reference:
https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/